### PR TITLE
feat: Implement mktg header

### DIFF
--- a/packages/ember-test-app/app/templates/marketing.hbs
+++ b/packages/ember-test-app/app/templates/marketing.hbs
@@ -4,8 +4,9 @@
     @icon="https://placehold.co/70x70"
     @title="KUB Fiber is available at {{this.address}}"
     @options={{this.headerOptions}}
-    @previousButton={{false}}
-    @nextButton={{true}}
+    @navButtons={{true}}
+    @previousButtonDisabled={{"disabled d-none"}}
+    @nextButtonDisabled={{"disabled"}}
   />
   <h4>Billing & Contact Information</h4>
   <hr class="my-4" />

--- a/packages/ember-test-app/app/templates/marketing.hbs
+++ b/packages/ember-test-app/app/templates/marketing.hbs
@@ -1,6 +1,12 @@
 {{page-title "MarketingTest"}}
-
 <main data-theme="marketing" class="container p-3">
+  <Nrg::Mktg::Header
+    @icon="https://placehold.co/70x70"
+    @title="KUB Fiber is available at {{this.address}}"
+    @options={{this.headerOptions}}
+    @previousButton={{false}}
+    @nextButton={{true}}
+  />
   <h4>Billing & Contact Information</h4>
   <hr class="my-4" />
   <form class="needs-validation" novalidate="">

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -126,6 +126,7 @@
     "app-js": {
       "./components/nrg/button.js": "./dist/_app_/components/nrg/button.js",
       "./components/nrg/mktg/card.js": "./dist/_app_/components/nrg/mktg/card.js",
+      "./components/nrg/mktg/header.js": "./dist/_app_/components/nrg/mktg/header.js",
       "./components/nrg/mktg/promo.js": "./dist/_app_/components/nrg/mktg/promo.js",
       "./components/nrg/text-field.js": "./dist/_app_/components/nrg/text-field.js"
     },

--- a/packages/ember/src/components/nrg/mktg/header.hbs
+++ b/packages/ember/src/components/nrg/mktg/header.hbs
@@ -1,28 +1,42 @@
-<div class="d-flex flex-row align-items-center justify-content-between p-2">
-  {{#if this.icon}}
-    <div>
-      <img src={{this.icon}} />
-    </div>
-  {{/if}}
-  <div class="d-flex flex-row justify-self-center">
+<div class="container-fluid w-100">
+  <div class="row row-cols-12 bg-primary text-light p-2 align-items-center">
+    {{#if this.icon}}
+      <div class="col">
+        <img src={{this.icon}} alt="Icon" />
+      </div>
+    {{/if}}
     {{#if this.title}}
-      <p class="fw-bold m-0">{{this.title}}</p>
+      <div
+        class="col d-flex flex-row justify-content-center justify-content-md-end"
+      >
+        <p class="fw-bold m-0 fs-4">{{this.title}}</p>
+      </div>
     {{/if}}
     {{#if this.options}}
-      {{#each this.options as |option|}}
-        {{#if option.label}}
-          <p>{{option.label}}</p>
-        {{/if}}
-        <LinkTo @route={{option.route}}>{{option.value}}</LinkTo>
-      {{/each}}
+      <div
+        class="mt-1 col-12 col-md-4 order-1 order-md-0 p-2 p-md-0 d-flex flex-row justify-content-center
+          {{if this.title 'justify-content-md-start'}}
+          align-items-center"
+      >
+        {{#each this.options as |option|}}
+          <p class="my-0 me-2 fw-bold">{{option.label}}</p>
+          <LinkTo
+            class="link-light me-2"
+            @route={{option.route}}
+          >{{option.value}}</LinkTo>
+        {{/each}}
+      </div>
     {{/if}}
-  </div>
-  <div class="d-flex justify-self-end">
-  {{#if this.previousButton}}
-    <Button>Prev</Button>
-  {{/if}}
-  {{#if this.nextButton}}
-    <ButtonComponent>Next</ButtonComponent>
-  {{/if}}
+    {{#if this.navButtons}}
+      <div class="col d-flex flex-row justify-content-end">
+        <Button
+          class="btn-outline-light me-1 rounded-pill
+            {{this.previousButtonDisabled}}"
+        >Prev</Button>
+        <Button
+          class="btn-outline-light rounded-pill {{this.nextButtonDisabled}}"
+        >Next</Button>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/packages/ember/src/components/nrg/mktg/header.hbs
+++ b/packages/ember/src/components/nrg/mktg/header.hbs
@@ -1,0 +1,28 @@
+<div class="d-flex flex-row align-items-center justify-content-between p-2">
+  {{#if this.icon}}
+    <div>
+      <img src={{this.icon}} />
+    </div>
+  {{/if}}
+  <div class="d-flex flex-row justify-self-center">
+    {{#if this.title}}
+      <p class="fw-bold m-0">{{this.title}}</p>
+    {{/if}}
+    {{#if this.options}}
+      {{#each this.options as |option|}}
+        {{#if option.label}}
+          <p>{{option.label}}</p>
+        {{/if}}
+        <LinkTo @route={{option.route}}>{{option.value}}</LinkTo>
+      {{/each}}
+    {{/if}}
+  </div>
+  <div class="d-flex justify-self-end">
+  {{#if this.previousButton}}
+    <Button>Prev</Button>
+  {{/if}}
+  {{#if this.nextButton}}
+    <ButtonComponent>Next</ButtonComponent>
+  {{/if}}
+  </div>
+</div>

--- a/packages/ember/src/components/nrg/mktg/header.js
+++ b/packages/ember/src/components/nrg/mktg/header.js
@@ -1,11 +1,12 @@
 import Component from '@glimmer/component';
 
-export default class MarketingHeaderComponent extends Component {
-  icon = this.args.icon;
-  title = this.args.title;
-  options = this.args.options;
-  previousButton = this.args.previousButton;
-  nextButton = this.args.nextButton;
+export default class HeaderComponent extends Component {
+  icon = this.args.icon || null;
+  title = this.args.title || '';
+  options = this.args.options || null;
+  navButtons = this.args.navButtons || false;
+  previousButtonDisabled = this.args.previousButtonDisabled || '';
+  nextButtonDisabled = this.args.nextButtonDisabled || '';
 
   constructor() {
     super(...arguments);

--- a/packages/ember/src/components/nrg/mktg/header.js
+++ b/packages/ember/src/components/nrg/mktg/header.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+
+export default class MarketingHeaderComponent extends Component {
+  icon = this.args.icon;
+  title = this.args.title;
+  options = this.args.options;
+  previousButton = this.args.previousButton;
+  nextButton = this.args.nextButton;
+
+  constructor() {
+    super(...arguments);
+  }
+}


### PR DESCRIPTION
This implementation of the header is extremely opinionated and relies on the correct parameters being passed to render correctly. However, it also does not require any styling during the implementation in order to match our given mock ups. I am also pushing up a version that offers high modularity but requires styling to achieve the desired look (see branch chesney-header-with-yields).

![image](https://github.com/user-attachments/assets/5a6beb38-3a67-47db-8f3c-7585efd9cf95)

![image](https://github.com/user-attachments/assets/b0c17516-f128-4c7f-abe5-f2b9a2ff9bdb)
