### PR TITLE
feat: Extract section header out of promo into a component

### DIFF
--- a/packages/ember-test-app/app/templates/faq.hbs
+++ b/packages/ember-test-app/app/templates/faq.hbs
@@ -1,6 +1,21 @@
 {{page-title "FAQs"}}
-<main data-theme="marketing" class="bg-primary-subtle vh-100 vw-100">
+<main data-theme="marketing" class="bg-primary-subtle vh-100 text-primary">
   <div class="container p-5">
+    <div class="row">
+      <Mktg::SectionHeader
+        class="col-12 col-lg-6"
+        @title="We're here to answer all of your questions!"
+        @subject="FAQs"
+      >
+        <:sub-content>
+          <div class="d-flex justify-content-center mb-4">
+            <Button type="button" class="mx-2 mt-2 btn btn-primary">Contact Us</Button>
+            <Button type="button" class="mx-2 mt-2 btn text-primary">Or call
+              (865)111-2323</Button>
+          </div>
+        </:sub-content>
+      </Mktg::SectionHeader>
+    </div>
     <Mktg::Faq @defaultOpen={{true}} @question="How does a FAQ Component work?">
       <:answer>
         <p>Once you click the icon in the upper right corner, this answer will

--- a/packages/ember-test-app/app/templates/faq.hbs
+++ b/packages/ember-test-app/app/templates/faq.hbs
@@ -7,13 +7,13 @@
         @title="We're here to answer all of your questions!"
         @subject="FAQs"
       >
-        <:sub-content>
+        <:subheader>
           <div class="d-flex justify-content-center mb-4">
             <Button type="button" class="mx-2 mt-2 btn btn-primary">Contact Us</Button>
             <Button type="button" class="mx-2 mt-2 btn text-primary">Or call
               (865)111-2323</Button>
           </div>
-        </:sub-content>
+        </:subheader>
       </Mktg::SectionHeader>
     </div>
     <Mktg::Faq @defaultOpen={{true}} @question="How does a FAQ Component work?">

--- a/packages/ember-test-app/app/templates/promo.hbs
+++ b/packages/ember-test-app/app/templates/promo.hbs
@@ -36,21 +36,24 @@
     </Container.Promo>
   </Mktg::PromoContainer>
   <div class="p-3"></div>
-  <Mktg::PromoContainer
-    @subject="Fiber Add-ons"
-    @title="Add TV and Phone Packages"
-    as |Container|
-  >
-    <Container.HeaderDescription>
-      <p class="m-0">KUB is installing its fiber optic cables alongside existing
-        electric wires. Fiber cables will be underground where electric lines
-        are underground, and overhead where electric lines are overhead.</p>
-      <div class="d-flex justify-content-center">
-        <Button type="button" class="mx-2 mt-2 btn btn-primary">Contact Us</Button>
-        <Button type="button" class="mx-2 mt-2 btn text-primary">Or call
-          (865)111-2323</Button>
-      </div>
-    </Container.HeaderDescription>
+  <Mktg::PromoContainer as |Container|>
+    <Container.SectionHeader
+      @subject="Fiber Add-ons"
+      @title="Add TV and Phone Packages"
+      class="col-12 col-lg-6"
+    >
+      <:sub-content>
+        <p class="m-0">KUB is installing its fiber optic cables alongside
+          existing electric wires. Fiber cables will be underground where
+          electric lines are underground, and overhead where electric lines are
+          overhead.</p>
+        <div class="d-flex justify-content-center mb-4">
+          <Button type="button" class="mx-2 mt-2 btn btn-primary">Contact Us</Button>
+          <Button type="button" class="mx-2 mt-2 btn text-primary">Or call
+            (865)111-2323</Button>
+        </div>
+      </:sub-content>
+    </Container.SectionHeader>
     <Container.Promo
       class="col-12 col-md-6 col-lg-4"
       @vertical={{true}}

--- a/packages/ember-test-app/app/templates/promo.hbs
+++ b/packages/ember-test-app/app/templates/promo.hbs
@@ -42,7 +42,7 @@
       @title="Add TV and Phone Packages"
       class="col-12 col-lg-6"
     >
-      <:sub-content>
+      <:subheader>
         <p class="m-0">KUB is installing its fiber optic cables alongside
           existing electric wires. Fiber cables will be underground where
           electric lines are underground, and overhead where electric lines are
@@ -52,7 +52,7 @@
           <Button type="button" class="mx-2 mt-2 btn text-primary">Or call
             (865)111-2323</Button>
         </div>
-      </:sub-content>
+      </:subheader>
     </Container.SectionHeader>
     <Container.Promo
       class="col-12 col-md-6 col-lg-4"

--- a/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
+++ b/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
@@ -8,8 +8,15 @@ module('Integration | components | mktg/promo-container', function (hooks) {
 
   test('Promo container renders', async function () {
     await render(<template>
-      <PromoContainer class="promo-container" as |Container|>
-        <Container.Promo class="promo" @productName="Product name">
+      <Mktg::PromoContainer class="promo-container" as |Container|>
+        <Container.SectionHeader
+          @title="Title"
+          @subject="Subject"
+          as |Section|
+          />
+        <Container.Promo class="promo"
+          @productName="Product name"
+        >
           <:img>
             <img src="https://place-hold.it/700x700" alt="Placeholder" />
           </:img>
@@ -28,7 +35,9 @@ module('Integration | components | mktg/promo-container', function (hooks) {
         '.container .row.p-4.text-primary.d-flex.justify-content-center.promo-container',
       )
       .exists('Promo container renders with correct classes');
-
+    assert
+      .dom('.container div .col-12.d-flex.flex-column.align-items-center')
+      .exists('Section header renders within container');
     assert.dom('.row.promo').exists('Promo renders within container');
   });
 });

--- a/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
+++ b/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
@@ -12,7 +12,6 @@ module('Integration | components | mktg/promo-container', function (hooks) {
         <Container.SectionHeader
           @title="Title"
           @subject="Subject"
-          as |Section|
           />
         <Container.Promo class="promo"
           @productName="Product name"

--- a/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
+++ b/packages/ember-test-app/tests/integration/components/mktg/promo-container-test.gts
@@ -8,14 +8,9 @@ module('Integration | components | mktg/promo-container', function (hooks) {
 
   test('Promo container renders', async function () {
     await render(<template>
-      <Mktg::PromoContainer class="promo-container" as |Container|>
-        <Container.SectionHeader
-          @title="Title"
-          @subject="Subject"
-          />
-        <Container.Promo class="promo"
-          @productName="Product name"
-        >
+      <PromoContainer class="promo-container" as |Container|>
+        <Container.SectionHeader @title="Title" @subject="Subject" />
+        <Container.Promo class="promo" @productName="Product name">
           <:img>
             <img src="https://place-hold.it/700x700" alt="Placeholder" />
           </:img>

--- a/packages/ember-test-app/tests/integration/components/mktg/section-header-test.gts
+++ b/packages/ember-test-app/tests/integration/components/mktg/section-header-test.gts
@@ -1,24 +1,19 @@
 import { assert, module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
+import SectionHeader from '@nrg-ui/ember/components/mktg/section-header';
 
 module('Integration | components | mktg/section-header', function (hooks) {
   setupRenderingTest(hooks);
 
   test('Section header renders', async function () {
-    await render(
-      hbs`<Mktg::SectionHeader
-        class="section-header"
-        @title="Title"
-        @subject="Subject"
-      >
+    await render(<template>
+      <SectionHeader class="section-header" @title="Title" @subject="Subject">
         <:subheader>
           <p>subheader</p>
         </:subheader>
-      </Mktg::SectionHeader>,
-      `,
-    );
+      </SectionHeader>,
+    </template>);
 
     assert
       .dom(

--- a/packages/ember-test-app/tests/integration/components/mktg/section-header-test.ts
+++ b/packages/ember-test-app/tests/integration/components/mktg/section-header-test.ts
@@ -1,0 +1,36 @@
+import { assert, module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | components | mktg/section-header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Section header renders', async function () {
+    await render(
+      hbs`<Mktg::SectionHeader
+        class="section-header"
+        @title="Title"
+        @subject="Subject"
+      >
+        <:sub-content>
+          <p>sub-content</p>
+        </:sub-content>
+      </Mktg::SectionHeader>,
+      `,
+    );
+
+    assert
+      .dom(
+        '.col-12.d-flex.flex-column.align-items-center .text-center.section-header',
+      )
+      .exists('Section header renders with passed attributes');
+    assert.dom('div div p').hasText('Subject', 'Subject renders within header');
+    assert
+      .dom('div div p:nth-of-type(2)')
+      .hasText('Title', 'Title renders within header');
+    assert
+      .dom('div div p:nth-of-type(3)')
+      .hasText('sub-content', 'Sub-content renders within named block');
+  });
+});

--- a/packages/ember-test-app/tests/integration/components/mktg/section-header-test.ts
+++ b/packages/ember-test-app/tests/integration/components/mktg/section-header-test.ts
@@ -13,9 +13,9 @@ module('Integration | components | mktg/section-header', function (hooks) {
         @title="Title"
         @subject="Subject"
       >
-        <:sub-content>
-          <p>sub-content</p>
-        </:sub-content>
+        <:subheader>
+          <p>subheader</p>
+        </:subheader>
       </Mktg::SectionHeader>,
       `,
     );
@@ -31,6 +31,6 @@ module('Integration | components | mktg/section-header', function (hooks) {
       .hasText('Title', 'Title renders within header');
     assert
       .dom('div div p:nth-of-type(3)')
-      .hasText('sub-content', 'Sub-content renders within named block');
+      .hasText('subheader', 'Subheader renders within named block');
   });
 });

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -144,6 +144,7 @@
       "./components/mktg/header.js": "./dist/_app_/components/mktg/header.js",
       "./components/mktg/promo-container.js": "./dist/_app_/components/mktg/promo-container.js",
       "./components/mktg/promo.js": "./dist/_app_/components/mktg/promo.js",
+      "./components/mktg/section-header.js": "./dist/_app_/components/mktg/section-header.js",
       "./components/nrg/text-field.js": "./dist/_app_/components/nrg/text-field.js",
       "./components/progress.js": "./dist/_app_/components/progress.js"
     },

--- a/packages/ember/src/components/mktg/promo-container.gts
+++ b/packages/ember/src/components/mktg/promo-container.gts
@@ -2,19 +2,7 @@ import type { TOC } from '@ember/component/template-only';
 import Promo from './promo.gts';
 import { hash } from '@ember/helper';
 import type { ComponentLike } from '@glint/template';
-
-interface HeaderDescriptionSignature {
-  Element: HTMLDivElement;
-  Blocks: {
-    default: [];
-  };
-}
-
-const HeaderDescription: TOC<HeaderDescriptionSignature> = <template>
-  <div class="text-center mb-5" ...attributes>
-    {{yield}}
-  </div>
-</template>;
+import SectionHeader from './section-header.gts';
 
 interface PromoContainerSignature {
   Element: HTMLDivElement;
@@ -25,7 +13,7 @@ interface PromoContainerSignature {
   Blocks: {
     default: [
       {
-        HeaderDescription: ComponentLike<typeof HeaderDescription>;
+        SectionHeader: ComponentLike<typeof SectionHeader>;
         Promo: ComponentLike<typeof Promo>;
       },
     ];
@@ -37,15 +25,8 @@ const PromoContainer: TOC<PromoContainerSignature> = <template>
       class="row p-4 text-primary d-flex justify-content-center"
       ...attributes
     >
-      <div class="col-12 text-center">
-        <p class="text-uppercase p-0 m-0 fw-semibold">{{@subject}}</p>
-        <p class="mx-0 my-2 fw-semibold fs-1">{{@title}}</p>
-      </div>
       {{yield
-        (hash
-          HeaderDescription=(component HeaderDescription)
-          Promo=(component Promo)
-        )
+        (hash SectionHeader=(component SectionHeader) Promo=(component Promo))
       }}
 
     </div>

--- a/packages/ember/src/components/mktg/section-header.gts
+++ b/packages/ember/src/components/mktg/section-header.gts
@@ -1,0 +1,24 @@
+import type { TOC } from '@ember/component/template-only';
+
+interface SectionHeaderSignature {
+  Element: HTMLDivElement;
+  Args: {
+    subject?: string;
+    title?: string;
+  };
+  Blocks: {
+    "sub-content": [];
+  };
+}
+
+const SectionHeader: TOC<SectionHeaderSignature> = <template>
+  <div class="col-12 d-flex flex-column align-items-center">
+    <div class="text-center" ...attributes>
+      <p class="text-uppercase p-0 m-0 fw-semibold">{{@subject}}</p>
+      <p class="mx-0 mb-2 fw-semibold fs-1">{{@title}}</p>
+      {{yield to="sub-content"}}
+    </div>
+  </div>
+</template>;
+
+export default SectionHeader;

--- a/packages/ember/src/components/mktg/section-header.gts
+++ b/packages/ember/src/components/mktg/section-header.gts
@@ -7,7 +7,7 @@ interface SectionHeaderSignature {
     title?: string;
   };
   Blocks: {
-    "sub-content": [];
+    subheader: [];
   };
 }
 
@@ -16,7 +16,7 @@ const SectionHeader: TOC<SectionHeaderSignature> = <template>
     <div class="text-center" ...attributes>
       <p class="text-uppercase p-0 m-0 fw-semibold">{{@subject}}</p>
       <p class="mx-0 mb-2 fw-semibold fs-1">{{@title}}</p>
-      {{yield to="sub-content"}}
+      {{yield to="subheader"}}
     </div>
   </div>
 </template>;


### PR DESCRIPTION
Since the section header that I originally implemented in the Promo Container is used in multiple places in the mock ups, I extracted it out into its own component. It has a parameter for title and subject, as well as a subheader named block for any additional content that may be needed such as links or descriptions. 
![image](https://github.com/user-attachments/assets/cc5edfb2-cdbb-46e2-917d-75809e641db6)
![image](https://github.com/user-attachments/assets/366df9c9-7831-457b-afd8-25b9bddb52af)
