### PR TITLE
refactor: Give freestyle cards responsive sizing

### DIFF
--- a/apps/ember-test-app/app/components/f/card.gts
+++ b/apps/ember-test-app/app/components/f/card.gts
@@ -17,7 +17,7 @@ export default class extends Component {
   hasHorizontalDivider = true;
 
   @tracked
-  class = 'col-6';
+  class = 'col-12 col-md-6';
 
   @action
   update(key: string, value: unknown) {

--- a/apps/ember-test-app/app/components/f/mktg/card.gts
+++ b/apps/ember-test-app/app/components/f/mktg/card.gts
@@ -8,7 +8,7 @@ import FreestyleSection from 'ember-freestyle/components/freestyle-section';
 
 export default class extends Component {
   @tracked
-  class = 'col-6 justify-content-start';
+  class = 'col-12 col-md-6';
 
   @tracked
   title = 'Title';


### PR DESCRIPTION
This helps with the sizing issue when on mobile devices in the freestyle docs. I wonder if there is a way to make the "Basics" and example section span the full width of the device rather than being about half of the width of the screen, but I wasn't able to find a solution yet.