### PR TITLE
style(header): Remove padding from header container

### DIFF
--- a/packages/ember-core/src/components/header.gts
+++ b/packages/ember-core/src/components/header.gts
@@ -11,7 +11,7 @@ interface HeaderSignature {
 }
 
 const HeaderComponent: TOC<HeaderSignature> = <template>
-  <div class="container-fluid">
+  <div class="container-fluid gx-0">
     <div
       class="row row-cols-12 bg-primary text-light p-1 align-items-center justify-content-evenly"
       ...attributes


### PR DESCRIPTION
The `container-fluid` class adds a default gutter. If that padding is desired, a class can be passed to the component. However, the default gutter cannot be removed as-is.