### PR TITLE
refactor: Remove primary blue background from headers

### DIFF
--- a/apps/docs-app/app/components/f/header.gts
+++ b/apps/docs-app/app/components/f/header.gts
@@ -8,7 +8,7 @@ import FreestyleSection from 'ember-freestyle/components/freestyle-section';
 
 export default class extends Component {
   @tracked
-  class = 'bg-primary';
+  class = 'text-primary';
 
   @action
   update(key: string, value: unknown) {

--- a/apps/docs-app/app/components/f/mktg/header.gts
+++ b/apps/docs-app/app/components/f/mktg/header.gts
@@ -9,7 +9,7 @@ import FreestyleSection from 'ember-freestyle/components/freestyle-section';
 
 export default class extends Component {
   @tracked
-  class = 'bg-primary';
+  class = 'text-primary';
 
   @tracked
   dropSection = false;
@@ -32,12 +32,8 @@ export default class extends Component {
                 <p class="m-0">Title</p>
               </:title>
               <:nav>
-                <Button
-                  class="btn-outline-light me-1 rounded-pill"
-                >Prev</Button>
-                <Button
-                  class="btn-outline-light me-1 rounded-pill"
-                >Next</Button>
+                <Button class="btn-outline-primary me-1">Prev</Button>
+                <Button class="btn-primary me-1">Next</Button>
               </:nav>
               <:options>
                 <p class="my-0 me-2 fw-bold">Option 1</p>

--- a/apps/test-app/tests/integration/components/mktg/faq-test.gts
+++ b/apps/test-app/tests/integration/components/mktg/faq-test.gts
@@ -17,7 +17,7 @@ module('Integration | Component | mktg/faq', function (hooks) {
     </template>);
 
     assert
-      .dom('.d-flex.flex-column.p-2.m-2.bg-white.rounded.test')
+      .dom('.d-flex.flex-column.p-2.m-2.rounded.test')
       .exists('FAQ renders with passed attributes');
 
     assert

--- a/packages/ember-core/src/components/header.gts
+++ b/packages/ember-core/src/components/header.gts
@@ -13,7 +13,7 @@ interface HeaderSignature {
 const HeaderComponent: TOC<HeaderSignature> = <template>
   <div class="container-fluid gx-0">
     <div
-      class="row row-cols-12 bg-primary text-light p-1 align-items-center justify-content-evenly"
+      class="row row-cols-12 p-1 align-items-center justify-content-evenly"
       ...attributes
     >
       <div class="col d-flex justify-content-start">

--- a/packages/ember-core/src/components/mktg/faq.gts
+++ b/packages/ember-core/src/components/mktg/faq.gts
@@ -40,11 +40,11 @@ export default class FaqComponent extends Component<FaqSignature> {
   }
 
   <template>
-    <div class="d-flex flex-column p-2 m-2 bg-white rounded" ...attributes>
+    <div class="d-flex flex-column p-2 m-2 rounded" ...attributes>
       <div class="d-flex justify-content-between align-items-center">
         <p class="fw-bold m-2">{{this.question}}</p>
         <button type="button" class="btn" {{on "click" this.toggleMenu}}><i
-            class="text-dark h2 {{this.menuIcon}}"
+            class="h2 {{this.menuIcon}}"
           /></button>
       </div>
       <div class="mx-2 mb-0 mt-2 {{this.classList}}">


### PR DESCRIPTION
This will make the header (both basic and marketing) default to a white background unless explicitly told a bg-color. Text is not given a default color, so that may be implemented as needed as well. 

I looked for other components that we may need to do this to in the future and went ahead and implemented the same changes for the FAQ component. 