### PR TITLE
refactor(presence): Set ignoreBlank option default to true

### DIFF
--- a/apps/test-app/tests/unit/validators/presence-test.ts
+++ b/apps/test-app/tests/unit/validators/presence-test.ts
@@ -62,7 +62,7 @@ module('Unit | Validator | inclusion', function (hooks) {
 
     this.model.field = ' ';
 
-    assert.isValid(validator.result);
+    assert.isInvalid(validator.result, 'This field cannot be blank');
 
     validator = new PresenceValidator(this.binding, { presence: false }, this);
 
@@ -72,7 +72,7 @@ module('Unit | Validator | inclusion', function (hooks) {
 
     this.model.field = ' ';
 
-    assert.isInvalid(validator.result, 'This field must be blank');
+    assert.isValid(validator.result);
 
     this.model.field = '';
 

--- a/packages/ember-core/src/validation/validators/presence.ts
+++ b/packages/ember-core/src/validation/validators/presence.ts
@@ -14,7 +14,7 @@ export type PresenceOptions = {
   presence: boolean;
   /**
    * Allow empty strings to be considered blank
-   * @default false
+   * @default true
    */
   ignoreBlank?: boolean;
 } & BaseOptions;

--- a/packages/ember-core/src/validation/validators/presence.ts
+++ b/packages/ember-core/src/validation/validators/presence.ts
@@ -26,7 +26,7 @@ export default class PresenceValidator<
 > extends BaseValidator<T, Model, Context, PresenceOptions> {
   defaultOptions = {
     presence: true,
-    ignoreBlank: false,
+    ignoreBlank: true,
   };
 
   constructor(


### PR DESCRIPTION
Setting this to true will make empty strings fail validations for the default presence validator and the required argument. 