### PR TITLE
fix: Add new margin to feature list

### DIFF
--- a/packages/ember-core/src/components/mktg/feature-list.gts
+++ b/packages/ember-core/src/components/mktg/feature-list.gts
@@ -36,7 +36,7 @@ export interface MktgFeatureListSignature {
 
 const Feature: TOC<MktgFeatureSignature> = <template>
   <p class="{{@class}}" ...attributes>
-    <span class="me-2 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
+    <span class="me-2 mt-1 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
   </p>
 </template>;
 


### PR DESCRIPTION
It looks like inside the flex boxes we needed a margin on the icons. I added mt-1 to the icons in nrg-ui. Then adding align-items-start to locations you want alignment will have it's intended affect.