### PR TITLE
fix: Center icon inside flex box

### DIFF
--- a/packages/ember-core/src/components/mktg/feature-list.gts
+++ b/packages/ember-core/src/components/mktg/feature-list.gts
@@ -36,7 +36,7 @@ export interface MktgFeatureListSignature {
 
 const Feature: TOC<MktgFeatureSignature> = <template>
   <p class="{{@class}}" ...attributes>
-    <span class="me-2 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
+    <span class="me-2 mt-1 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
   </p>
 </template>;
 


### PR DESCRIPTION
This will move icons more to the center of the flex box when using d-flex.