### PR TITLE
fix: Change icon spacing based on type

### DIFF
--- a/packages/ember-core/src/components/mktg/feature-list.gts
+++ b/packages/ember-core/src/components/mktg/feature-list.gts
@@ -15,7 +15,6 @@ const columnMap = {
 export interface MktgFeatureSignature {
   Args: {
     icon?: string;
-    alphaNumeric?: boolean;
     text?: string;
     meta?: string;
     class: string;
@@ -36,15 +35,9 @@ export interface MktgFeatureListSignature {
 }
 
 const Feature: TOC<MktgFeatureSignature> = <template>
-  {{#if @alphaNumeric}}
-    <p class="{{@class}}" ...attributes>
-      <span class="me-2 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
-    </p>
-  {{else}}
-    <p class="{{@class}}" ...attributes>
-      <span class="me-2 mt-1 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
-    </p>
-  {{/if}}
+  <p class="align-items-baseline {{@class}}" ...attributes>
+    <span class="me-2 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
+  </p>
 </template>;
 
 export default class MktgFeatureList extends Component<MktgFeatureListSignature> {

--- a/packages/ember-core/src/components/mktg/feature-list.gts
+++ b/packages/ember-core/src/components/mktg/feature-list.gts
@@ -35,9 +35,15 @@ export interface MktgFeatureListSignature {
 }
 
 const Feature: TOC<MktgFeatureSignature> = <template>
-  <p class="{{@class}}" ...attributes>
-    <span class="me-2 mt-1 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
-  </p>
+  {{#if @alphaNumeric}}
+    <p class="{{@class}}" ...attributes>
+      <span class="me-2 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
+    </p>
+  {{else}}
+    <p class="{{@class}}" ...attributes>
+      <span class="me-2 mt-1 fw-bold bi {{@icon}}">{{@meta}}</span>{{@text}}
+    </p>
+  {{/if}}
 </template>;
 
 export default class MktgFeatureList extends Component<MktgFeatureListSignature> {

--- a/packages/ember-core/src/components/mktg/feature-list.gts
+++ b/packages/ember-core/src/components/mktg/feature-list.gts
@@ -15,6 +15,7 @@ const columnMap = {
 export interface MktgFeatureSignature {
   Args: {
     icon?: string;
+    alphaNumeric?: boolean;
     text?: string;
     meta?: string;
     class: string;


### PR DESCRIPTION
The previous change corrected icon spacing for image based icons but alpha-numeric icons are now misaligned. This should add a property that, when true, any alpha-numeric character inside the icon property within `d-flex` flex boxes will be aligned evenly.