### PR TITLE
refactor: Use d-none instead of hidden for popovers

### DIFF
--- a/apps/test-app/tests/integration/components/popover-test.gts
+++ b/apps/test-app/tests/integration/components/popover-test.gts
@@ -89,11 +89,11 @@ module('Integration | Component | popover', function (hooks) {
       </Popover>
     </template>);
 
-    assert.dom('.popover').hasClass('hidden');
+    assert.dom('.popover').hasClass('d-none');
 
     await click('button');
 
-    assert.dom('.popover').doesNotHaveClass('hidden');
+    assert.dom('.popover').doesNotHaveClass('d-none');
 
     await click('button');
 

--- a/apps/test-app/tests/integration/components/tooltip-test.gts
+++ b/apps/test-app/tests/integration/components/tooltip-test.gts
@@ -112,15 +112,15 @@ module('Integration | Component | tooltip', function (hooks) {
 
     await render(<template><Tooltip @onShow={{show}} @onHide={{hide}} /></template>);
 
-    assert.dom('.tooltip').hasClass('hidden');
+    assert.dom('.tooltip').hasClass('d-none');
 
     assert.step('beforeShow');
     await triggerEvent('span:has(> p)', 'mouseenter');
-    assert.dom('.tooltip').doesNotHaveClass('hidden');
+    assert.dom('.tooltip').doesNotHaveClass('d-none');
 
     assert.step('beforeHide');
     await triggerEvent('span:has(> p)', 'mouseleave');
-    assert.dom('.tooltip').hasClass('hidden');
+    assert.dom('.tooltip').hasClass('d-none');
 
     assert.verifySteps(['beforeShow', 'show', 'beforeHide', 'hide']);
   });

--- a/packages/ember-core/src/components/popover.gts
+++ b/packages/ember-core/src/components/popover.gts
@@ -270,7 +270,7 @@ export default class Popover extends Component<PopoverSignature> {
       <div
         id={{this.id}}
         class={{classes
-          (unless this.isShown "hidden")
+          (unless this.isShown "d-none")
           (concat "popover bs-popover-" this.adjustedSide)
         }}
         {{onInsert this.initPopover}}


### PR DESCRIPTION
This prevents the popover from taking up dom space when it isn't visible - fixes the sticky header and white space issues we saw in implementation