### PR TITLE
refactor: Allow all app bar options in each section

### DIFF
--- a/docs/app/templates/application.hbs
+++ b/docs/app/templates/application.hbs
@@ -2,12 +2,12 @@
 
 {{! BEGIN-SNIPPET scaffold-component }}
 <Scaffold @environment={{this.environment}}>
-  <:app-bar-center as |AppBar|>
+  <:app-bar-left as |AppBar|>
     <h5 class="d-none d-md-block m-0">
       Docs | @nrg-ui/core
     </h5>
     <AppBar.Environment />
-  </:app-bar-center>
+  </:app-bar-left>
   <:sidebar as |Menu|>
     <Menu.Item @route="scaffold">
       Scaffold

--- a/docs/app/templates/application.hbs
+++ b/docs/app/templates/application.hbs
@@ -3,9 +3,9 @@
 {{! BEGIN-SNIPPET scaffold-component }}
 <Scaffold @environment={{this.environment}}>
   <:app-bar-left as |AppBar|>
-    <h5 class="d-none d-md-block m-0">
+    <p class="d-none d-md-block m-0 fs-5">
       Docs | @nrg-ui/core
-    </h5>
+    </p>
     <AppBar.Environment />
   </:app-bar-left>
   <:sidebar as |Menu|>

--- a/docs/tests/integration/components/app-bar-test.gts
+++ b/docs/tests/integration/components/app-bar-test.gts
@@ -34,17 +34,6 @@ module('Integration | Component | app-bar', function (hooks) {
       .hasText('Mobile drop section');
   });
 
-  test('environment renders when applicable', async function (assert) {
-    await render(<template><AppBar @environment="dev" /></template>);
-    assert.dom('.environment-title').hasText('dev');
-
-    await render(<template><AppBar @environment="test" /></template>);
-    assert.dom('.environment-title').hasText('test');
-
-    await render(<template><AppBar @environment="prod" /></template>);
-    assert.dom('.environment-title').doesNotExist();
-  });
-
   test('environment can be rendered in custom location', async function (assert) {
     await render(<template>
       <AppBar @environment="dev">

--- a/packages/ember-core/src/components/app-bar.gts
+++ b/packages/ember-core/src/components/app-bar.gts
@@ -30,63 +30,44 @@ const EnvironmentDisplay: TOC<EnvironmentDisplaySignature> = <template>
   {{/let}}
 </template>;
 
+export interface AppBarBlock {
+  Environment: ComponentLike<EnvironmentDisplaySignature>;
+}
+
 export interface AppBarSignature {
   Element: HTMLDivElement;
   Args: {
     environment?: string;
   };
   Blocks: {
-    left: [];
-    right: [];
-    center: [
-      {
-        Environment: ComponentLike<EnvironmentDisplaySignature>;
-      },
-    ];
-    'mobile-drop-section': [
-      {
-        Environment: ComponentLike<EnvironmentDisplaySignature>;
-      },
-    ];
+    left: [AppBarBlock];
+    right: [AppBarBlock];
+    center: [AppBarBlock];
+    'mobile-drop-section': [AppBarBlock];
   };
 }
 
 const AppBar: TOC<AppBarSignature> = <template>
   <div class="app-bar-container">
-    <Header class="app-bar text-bg-primary shadow-sm py-2" ...attributes>
-      <:left>
-        {{yield to="left"}}
-      </:left>
-      <:center>
-        {{#if (has-block "center")}}
-          {{yield
-            (hash
-              Environment=(component
-                EnvironmentDisplay environment=@environment
-              )
-            )
-            to="center"
-          }}
-        {{else}}
-          <EnvironmentDisplay @environment={{@environment}} />
-        {{/if}}
-      </:center>
-      <:right>
-        {{yield to="right"}}
-      </:right>
-      <:mobile-drop-section>
-        {{#if (has-block "mobile-drop-section")}}
-          {{yield
-            (hash
-              Environment=(component
-                EnvironmentDisplay environment=@environment
-              )
-            )
-            to="mobile-drop-section"
-          }}
-        {{/if}}
-      </:mobile-drop-section>
-    </Header>
+    {{#let
+      (hash Environment=(component EnvironmentDisplay environment=@environment))
+      as |AppBarYield|
+    }}
+      <Header class="app-bar text-bg-primary shadow-sm py-2" ...attributes>
+        <:left>
+          {{yield AppBarYield to="left"}}
+        </:left>
+        <:center>
+          {{yield AppBarYield to="center"}}
+        </:center>
+        <:right>
+          {{yield AppBarYield to="right"}}
+        </:right>
+        <:mobile-drop-section>
+          {{yield AppBarYield to="mobile-drop-section"}}
+        </:mobile-drop-section>
+      </Header>
+    {{/let}}
   </div>
 </template>;
 

--- a/packages/ember-core/src/components/header.gts
+++ b/packages/ember-core/src/components/header.gts
@@ -15,20 +15,20 @@ const HeaderComponent: TOC<HeaderSignature> = <template>
     class="row row-cols-12 p-1 align-items-center justify-content-evenly"
     ...attributes
   >
-    <div class="col d-flex justify-content-start">
+    <div class="col d-flex justify-content-start align-items-center">
       {{yield to="left"}}
     </div>
     {{#if (has-block "center")}}
-      <div class="col d-flex justify-content-center flex-row flex-no-wrap">
+      <div class="col d-flex justify-content-center align-items-center flex-row flex-no-wrap">
         {{yield to="center"}}
       </div>
     {{/if}}
-    <div class="col d-flex justify-content-end">
+    <div class="col d-flex justify-content-end align-items-center">
       {{yield to="right"}}
     </div>
     {{#if (has-block "mobile-drop-section")}}
       <div class="d-flex col-12 d-md-none order-last justify-content-center">
-        <div class="d-flex flex-row text-nowrap">
+        <div class="d-flex flex-row text-nowrap align-items-center">
           {{yield to="mobile-drop-section"}}
         </div>
       </div>

--- a/packages/ember-core/src/components/scaffold.gts
+++ b/packages/ember-core/src/components/scaffold.gts
@@ -15,15 +15,13 @@ import Sidebar from './sidebar.gts';
 import Toaster from './toaster.gts';
 import version from '../helpers/version.ts';
 
-import type { AppBarSignature } from './app-bar.gts';
+import type { AppBarBlock } from './app-bar.gts';
 import type { GroupSignature, ItemSignature } from './sidebar.gts';
 import type { Dropdown as ContextMenuType } from '../services/context-menu.ts';
 import type ResponsiveService from '../services/responsive.ts';
 import type ThemeService from '../services/theme.ts';
 import type { ComponentLike } from '@glint/template';
 import type { IntlService } from 'ember-intl';
-
-type AppBarYieldType = AppBarSignature['Blocks']['center'][0];
 
 type EnvironmentConfig = Record<string, string> & {
   modulePrefix: string;
@@ -36,10 +34,10 @@ export interface ScaffoldSignature {
     environment?: string;
   };
   Blocks: {
-    'app-bar-left': [];
-    'app-bar-center': [AppBarYieldType];
-    'app-bar-right': [];
-    'app-bar-mobile-drop-section': [];
+    'app-bar-left': [AppBarBlock];
+    'app-bar-center': [AppBarBlock];
+    'app-bar-right': [AppBarBlock];
+    'app-bar-mobile-drop-section': [AppBarBlock];
     'context-menu': [ContextMenuType];
     default: [];
     'footer-left': [];
@@ -118,7 +116,7 @@ export default class Scaffold extends Component<ScaffoldSignature> {
     }}
       <div class="min-vh-100 d-flex flex-column">
         <AppBar @environment={{@environment}}>
-          <:left>
+          <:left as |AppBar|>
             {{#if hasSidebar}}
               <i
                 class="bi-{{this.sidebarIcon}} fs-4 px-3"
@@ -126,16 +124,13 @@ export default class Scaffold extends Component<ScaffoldSignature> {
                 {{on "click" this.toggleSidebar}}
               />
             {{/if}}
-            {{yield to="app-bar-left"}}
+            {{yield AppBar to="app-bar-left"}}
           </:left>
           <:center as |AppBar|>
             {{yield AppBar to="app-bar-center"}}
-            {{#unless (has-block-params "app-bar-center")}}
-              <AppBar.Environment />
-            {{/unless}}
           </:center>
-          <:right>
-            {{yield to="app-bar-right"}}
+          <:right as |AppBar|>
+            {{yield AppBar to="app-bar-right"}}
             <ContextMenu class="pe-2" @flip={{true}} @id="application">
               <:default as |Menu|>
                 {{yield Menu to="context-menu"}}
@@ -182,8 +177,8 @@ export default class Scaffold extends Component<ScaffoldSignature> {
               {{t "nrg.app-bar.about.item"}}
             </ContextMenuItem>
           </:right>
-          <:mobile-drop-section>
-            {{yield to="app-bar-mobile-drop-section"}}
+          <:mobile-drop-section as |AppBar|>
+            {{yield AppBar to="app-bar-mobile-drop-section"}}
           </:mobile-drop-section>
         </AppBar>
         <div class="application" ...attributes>


### PR DESCRIPTION
By aligning the environment in the center of the app bar while aligning primary content in the middle of the main page content, the center of the app bar did not line up center of the application (if the sidebar was open). Applications should be able to do that, but we shouldn't force the environment in a particular place.