### PR TITLE
feat: Create helper to lookup service in a template

### DIFF
--- a/docs/tests/integration/helpers/lookup-service-test.gts
+++ b/docs/tests/integration/helpers/lookup-service-test.gts
@@ -1,0 +1,37 @@
+import { render } from '@ember/test-helpers';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
+import lookupService from '@nrg-ui/core/helpers/lookup-service';
+import { setupRenderingTest } from 'docs/tests/helpers';
+import { module, test } from 'qunit';
+
+module('Integration | Helper | lookup-service', function (hooks) {
+  setupRenderingTest(hooks);
+
+  if (
+    macroCondition(dependencySatisfies('ember-source', '^6.3.0')) ? false : true
+  ) {
+    test('it looks up services', async function (assert) {
+      assert.expect(1);
+
+      const router = this.owner.lookup('service:router');
+
+      function compare(service: unknown) {
+        assert.strictEqual(service, router);
+      }
+
+      await render(<template>{{compare (lookupService "router")}}</template>);
+    });
+
+    test('non-existent services return undefined', async function (assert) {
+      assert.expect(1);
+
+      function compare(service: unknown) {
+        assert.strictEqual(service, undefined);
+      }
+
+      await render(<template>
+        {{compare (lookupService "i-don't-exist")}}
+      </template>);
+    });
+  }
+});

--- a/packages/ember-core/package.json
+++ b/packages/ember-core/package.json
@@ -227,6 +227,7 @@
       "./helpers/bind.js": "./dist/_app_/helpers/bind.js",
       "./helpers/classes.js": "./dist/_app_/helpers/classes.js",
       "./helpers/index.js": "./dist/_app_/helpers/index.js",
+      "./helpers/lookup-service.js": "./dist/_app_/helpers/lookup-service.js",
       "./helpers/version.js": "./dist/_app_/helpers/version.js",
       "./initializers/dayjs-plugins.js": "./dist/_app_/initializers/dayjs-plugins.js",
       "./modifiers/index.js": "./dist/_app_/modifiers/index.js",

--- a/packages/ember-core/src/helpers/index.ts
+++ b/packages/ember-core/src/helpers/index.ts
@@ -1,5 +1,6 @@
 import Bind, { bind } from './bind.ts';
 import Classes, { classes } from './classes.ts';
+import lookupService from './lookup-service.ts';
 import Version, { version } from './version.ts';
 
 export default {
@@ -8,5 +9,6 @@ export default {
   Version,
   bind,
   classes,
+  lookupService,
   version,
 }

--- a/packages/ember-core/src/helpers/lookup-service.ts
+++ b/packages/ember-core/src/helpers/lookup-service.ts
@@ -1,0 +1,49 @@
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+import { getOwner } from '@ember/owner';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
+
+import type { DIRegistry } from '@ember/owner';
+
+export interface LookupServiceSignature<
+  Name extends keyof DIRegistry['service'] & string,
+> {
+  Args: {
+    Positional: [Name];
+    Named: {
+      singleton?: boolean;
+    };
+  };
+  Return: DIRegistry['service'][Name];
+}
+
+export default class LookupService<
+  Name extends keyof DIRegistry['service'] & string,
+> extends Helper<LookupServiceSignature<Name>> {
+  compute(
+    [name]: [Name],
+    { singleton }: { singleton?: boolean },
+  ): DIRegistry['service'][Name] {
+    if (macroCondition(dependencySatisfies('ember-source', '^6.3.0'))) {
+      assert(
+        'Use of the `lookup-service` helper is not allowed with `ember-source` 6.3.0 or above.' +
+          'Instead, use the template tag syntax (.gjs or.gts file) to build a route component.',
+      );
+    }
+    if (macroCondition(dependencySatisfies('ember-route-templates', '*'))) {
+      assert(
+        'Use of the `lookup-service` helper is not allowed with `ember-route-templates`.' +
+          'Instead, use the template tag syntax (.gjs or.gts file) and the `Route` function ' +
+          'from `ember-route-templates` to build a route component.',
+      );
+    }
+
+    assert('Service name must be provided', name);
+
+    const owner = getOwner(this);
+
+    return owner!.lookup(`service:${name}`, {
+      singleton,
+    });
+  }
+}

--- a/packages/ember-core/src/index.ts
+++ b/packages/ember-core/src/index.ts
@@ -53,6 +53,7 @@ export { default as Tooltip } from './components/tooltip.gts';
 /* Helpers */
 export { bind, default as Bind } from './helpers/bind.ts';
 export { classes, default as Classes } from './helpers/classes.ts';
+export { default as lookupService } from './helpers/lookup-service.ts';
 export { default as Version, version } from './helpers/version.ts';
 
 /* Modifiers */

--- a/packages/ember-core/src/template-registry.ts
+++ b/packages/ember-core/src/template-registry.ts
@@ -39,6 +39,7 @@ import Scaffold from './components/scaffold.gts';
 import Sidebar from './components/sidebar.gts';
 import Toaster from './components/toaster.gts';
 import Bind from './helpers/bind.ts';
+import LookupService from './helpers/lookup-service.ts';
 import Version from './helpers/version.ts';
 import OnClickOutside from './modifiers/on-click-outside.ts';
 import OnInsert from './modifiers/on-insert.ts';
@@ -94,6 +95,7 @@ export interface ComponentRegistry {
 
 export interface HelperRegistry {
   bind: typeof Bind;
+  'lookup-service': typeof LookupService;
   version: typeof Version;
 }
 


### PR DESCRIPTION
Oftentimes I've had to create a controller solely to lookup a service that can be used in a Handlebars template. This helper can be used instead, specifically in combination with the `{{#let}}` helper:
```hbs
{{#let (lookup-service "session") as |session|}}
  {{#if session.isAuthenticated}}
    ...
  {{else}}
    ...
  {{/if}}
{{/let}}
```

This helper is not necessary when using Ember.js 6.3 or above, or if using the `ember-route-template` addon. To combat it being used inappropriately, an error will be thrown if either of those dependency conditions are satisfied.