### PR TITLE
style: Remove border rounding on sidebar items

### DIFF
--- a/packages/design-system/src/custom/_scaffold.scss
+++ b/packages/design-system/src/custom/_scaffold.scss
@@ -45,6 +45,10 @@
   & > .list-group {
     padding: var(--bs-list-group-item-padding-y) 0;
 
+    & > .list-group-item {
+      border-radius: 0;
+    }
+
     &.footer {
       border-top-width: var(--bs-list-group-border-width);
       border-radius: 0;


### PR DESCRIPTION
The first and last child have rounding applied to the top and bottom borders, respectively. This doesn't look correct with the items in the sidebar