### PR TITLE
fix(marketing header): Add flex collapse attribute to fix mobile styling

### DIFF
--- a/docs/app/components/f/mktg-components/header.gts
+++ b/docs/app/components/f/mktg-components/header.gts
@@ -15,6 +15,9 @@ export default class HeaderDemo extends Component {
   @tracked
   dropSection = false;
 
+  @tracked
+  flexCollapse = false;
+
   @action
   update(key: string, value: unknown) {
     this[key] = value;
@@ -25,7 +28,7 @@ export default class HeaderDemo extends Component {
       <Section.subsection @name="Basics">
         <FreestyleUsage>
           <:example>
-            <MktgHeader class={{this.class}} @dropSection={{this.dropSection}}>
+            <MktgHeader class={{this.class}} @dropSection={{this.dropSection}}  @flexCollapse={{this.flexCollapse}}>
               <:brand>
                 <img src="https://imageplaceholder.net/50" alt="Icon" />
               </:brand>
@@ -57,6 +60,12 @@ export default class HeaderDemo extends Component {
               @type="Bool"
               @value={{this.dropSection}}
               @onInput={{fn this.update "dropSection"}}
+            />
+            <Args.Bool
+              @name="flexCollapse"
+              @description="Each of the sections of the flexbox container shrink to fit the content. Each section is also evenly spaced. This is most useful when one of the header sections contains more content than the others."
+              @value={{this.flexCollapse}}
+              @onInput={{fn this.update "flexCollapse"}}
             />
             <Args.Yield
               @description="Named yield block to render branding content such as icons"

--- a/packages/ember-core/src/components/mktg/header.gts
+++ b/packages/ember-core/src/components/mktg/header.gts
@@ -6,6 +6,7 @@ export interface MktgHeaderSignature {
   Element: HTMLDivElement;
   Args: {
     dropSection: boolean;
+    flexCollapse: boolean;
   };
   Blocks: {
     brand: [];
@@ -18,6 +19,7 @@ export interface MktgHeaderSignature {
 const Header: TOC<MktgHeaderSignature> = <template>
   <HeaderComponent
     class="bg-body top-0 sticky-top w-100 gx-0 border border-bottom"
+    @flexCollapse={{@flexCollapse}}
     ...attributes
   >
     <:left>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/5eefe6c7-abce-4ba5-bad8-2c3e58c74a90)
After:
![image](https://github.com/user-attachments/assets/228d5250-3b31-4b18-b6ce-ff0dd0854bec)

