### PR TITLE
chore(ci): Enable testing for Ember 6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - ember-5.9
           - ember-lts-5.12
           - ember-6.0
+          - ember-6.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/docs/config/ember-try.js
+++ b/docs/config/ember-try.js
@@ -29,6 +29,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-6.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~6.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
With 6.4 being released and only a couple months from LTS, we should start testing this new version in preparation. Once 6.4 is moved to LTS, we should mark this new test as required.