### PR TITLE
chore(dependabot): Don't upgrade Chalk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
           - 'patch'
           - 'minor'
     ignore:
+      - dependency-name: 'chalk'
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: 'ember-source'
         update-types:
           - 'version-update:semver-minor'


### PR DESCRIPTION
Blueprints are written as CommonJS so they still require Chalk v4 - Chalk v5 is ESM-only and not compatible with a CJS source.