### PR TITLE
fix(validations): Track registered bindings

### DIFF
--- a/docs/app/components/f/components/form/index.gts
+++ b/docs/app/components/f/components/form/index.gts
@@ -25,7 +25,7 @@ const Validators = {
   textArea: [
     validator('custom', {
       validate(value) {
-        console.log('Validating: ' + value);
+        console.log(`Validating: '${value}'`);
         return value !== 'foo';
       },
       isWarning: true,
@@ -90,8 +90,18 @@ const Validators = {
     validator('length', {
       between: [1, 4],
       message: 'No more than 4 files can be uploaded',
-    })
-  ]
+    }),
+  ],
+  checkbox2: [
+    validator('custom', {
+      validate(value) {
+        if (value != 'because') {
+          return 'You must provide a reason';
+        }
+        return true;
+      },
+    }),
+  ],
 };
 
 class Model {
@@ -299,7 +309,7 @@ export default class FormDemo extends Component {
           </Field.Checkbox>
         </Form.Field>
         {{#if this.model.checkbox}}
-          <Form.Field @required={{true}} as |Field|>
+          <Form.Field @label="Why not?" @required={{this.required}} as |Field|>
             <Field.TextInput @binding={{bind this.model "checkbox2"}} />
           </Form.Field>
         {{/if}}

--- a/packages/ember-core/src/components/form/bound-value.ts
+++ b/packages/ember-core/src/components/form/bound-value.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { action, get, set } from '@ember/object';
 import Component from '@glimmer/component';
-import { scheduleTask } from 'ember-lifeline';
+import { runTask, scheduleTask } from 'ember-lifeline';
 
 import { ensurePathExists } from '../../utils/ensure-path-exists.ts';
 
@@ -54,7 +54,9 @@ export default class BoundValue<Signature, T> extends Component<
       });
     }
 
-    this.args.initBinding?.(binding);
+    runTask(this, () => {
+      this.args.initBinding?.(binding);
+    });
   }
 
   get model() {

--- a/packages/ember-core/src/components/form/checkbox-group.gts
+++ b/packages/ember-core/src/components/form/checkbox-group.gts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+import { runTask } from 'ember-lifeline';
 import { TrackedSet } from 'tracked-built-ins';
 
 import Checkbox from './checkbox.gts';
@@ -37,7 +38,9 @@ export default class CheckboxGroup extends Component<CheckboxGroupSignature> {
   constructor(owner: Owner, args: CheckboxGroupSignature['Args']) {
     super(owner, args);
 
-    args.onInitBinding?.(bind(this, 'value'));
+    runTask(this, () => {
+      args.onInitBinding?.(bind(this, 'value'));
+    });
   }
 
   get value() {

--- a/packages/ember-core/src/components/form/field.gts
+++ b/packages/ember-core/src/components/form/field.gts
@@ -174,7 +174,7 @@ export default class Field extends Component<FieldSignature> {
   }
 
   get validatorKey() {
-    return this.args.validatorKey ?? this.binding.valuePath;
+    return this.args.validatorKey ?? this.binding?.valuePath;
   }
 
   get describedBy() {

--- a/packages/ember-core/src/components/form/index.gts
+++ b/packages/ember-core/src/components/form/index.gts
@@ -82,7 +82,7 @@ export default class Form extends Component<FormSignature> implements FormType {
     super(owner, args);
 
     this.staticValidations = new TrackedMap();
-    this.bindings = new Map();
+    this.bindings = new TrackedMap();
   }
 
   get didValidate() {


### PR DESCRIPTION
There's a new bug where it appears some validations run more than once, even if the value they're following hasn't changed. This is likely to be less of an issue than what this PR fixes, so I'm okay with this for the time being.

Resolves #514.